### PR TITLE
AWS Terraform changes for attaching managed IAM policies

### DIFF
--- a/AWS/terraform/Dome9FullManage.tf
+++ b/AWS/terraform/Dome9FullManage.tf
@@ -52,16 +52,14 @@ resource "aws_iam_policy_attachment" "attach-d9-write-policy" {
   policy_arn = "${aws_iam_policy.write-policy.arn}"
 }
 
-resource "aws_iam_policy_attachment" "attach-security-audit" {
-  name       = "Attach-readonly"
-  roles      = ["${aws_iam_role.dome9.name}"]
-  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+resource "aws_iam_role_policy_attachment" "attach-security-audit" {
+    role       = "${aws_iam_role.dome9.name}"
+    policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
 
-resource "aws_iam_policy_attachment" "attach-inspector-readonly" {
-  name       = "Attach-readonly"
-  roles      = ["${aws_iam_role.dome9.name}"]
-  policy_arn = "arn:aws:iam::aws:policy/AmazonInspectorReadOnlyAccess"
+resource "aws_iam_role_policy_attachment" "attach-inspector-readonly" {
+    role       = "${aws_iam_role.dome9.name}"
+    policy_arn = "arn:aws:iam::aws:policy/AmazonInspectorReadOnlyAccess"
 }
 
 #Output the role ARN

--- a/AWS/terraform/Dome9ReadOnly.tf
+++ b/AWS/terraform/Dome9ReadOnly.tf
@@ -39,16 +39,14 @@ resource "aws_iam_policy_attachment" "attach-d9-read-policy" {
   policy_arn = "${aws_iam_policy.readonly-policy.arn}"
 }
 
-resource "aws_iam_policy_attachment" "attach-security-audit" {
-  name       = "attach-security-audit"
-  roles      = ["${aws_iam_role.dome9.name}"]
-  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+resource "aws_iam_role_policy_attachment" "attach-security-audit" {
+    role       = "${aws_iam_role.dome9.name}"
+    policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
 
-resource "aws_iam_policy_attachment" "attach-inspector-readonly" {
-  name       = "attach-inspector-readonly"
-  roles      = ["${aws_iam_role.dome9.name}"]
-  policy_arn = "arn:aws:iam::aws:policy/AmazonInspectorReadOnlyAccess"
+resource "aws_iam_role_policy_attachment" "attach-inspector-readonly" {
+    role       = "${aws_iam_role.dome9.name}"
+    policy_arn = "arn:aws:iam::aws:policy/AmazonInspectorReadOnlyAccess"
 }
 
 

--- a/AWS/terraform/readonly-policy.json
+++ b/AWS/terraform/readonly-policy.json
@@ -22,7 +22,7 @@
                 "lambda:List*",
                 "s3:List*",
                 "sns:ListSubscriptions",
-                "sns:ListSubscriptionsByTopic"
+                "sns:ListSubscriptionsByTopic",
                 "waf-regional:ListResourcesForWebACL"
             ],
             "Effect": "Allow",


### PR DESCRIPTION
Changed the IAM resource for attaching AWS managed policies from [aws_iam_policy_attachment](https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html) to [aws_iam_role_policy_attachment](https://www.terraform.io/docs/providers/aws/r/iam_role_policy_attachment.html).  The former method wants exclusive attachment to the policy and will revoke all other attachments.  

Also, fixed the readonly-policy.json which was failing validation (parsing error).