### PR TITLE
ignore assume_role errors

### DIFF
--- a/AWS/full_automation/d9_onboard_aws.py
+++ b/AWS/full_automation/d9_onboard_aws.py
@@ -309,7 +309,7 @@ def mode_organizations_onboard(orgclient, stsclient, cfclient):
                 DurationSeconds=1800
                 )
             except ClientError:
-                print("Could not assume role for account {}".format(account['name']))
+                print(f'\nCould not assume role for account {account["name"]}')
                 count_failures += 1
                 if OPTIONS.ignore_failures:
                     continue

--- a/AWS/full_automation/d9_onboard_aws.py
+++ b/AWS/full_automation/d9_onboard_aws.py
@@ -302,11 +302,19 @@ def mode_organizations_onboard(orgclient, stsclient, cfclient):
             assume_role_arn = 'arn:aws:iam::' + account['id'] + ':role/' + OPTIONS.role_name # Build role ARN of target account being onboarded to assume into
             print(f'\nAssuming Role into target account using ARN: {assume_role_arn}') 
 
-            stsresp = stsclient.assume_role(
-             RoleArn=assume_role_arn,
-             RoleSessionName='DeployDome9CFTSession',
-             DurationSeconds=1800
-             )
+            try:
+                stsresp = stsclient.assume_role(
+                RoleArn=assume_role_arn,
+                RoleSessionName='DeployDome9CFTSession',
+                DurationSeconds=1800
+                )
+            except ClientError:
+                print("Could not assume role for account {}".format(account['name']))
+                count_failures += 1
+                if OPTIONS.ignore_failures:
+                    continue
+                else:
+                    os._exit(1)
             cfclient = boto3.client('cloudformation',
              aws_access_key_id=stsresp['Credentials']['AccessKeyId'],
              aws_secret_access_key=stsresp['Credentials']['SecretAccessKey'],


### PR DESCRIPTION
Wrap `assume_role` in try/except and continue if `ClientError` is encountered. This allows for automatic onboarding of all org accounts in one run, skipping accounts for which target role doesn't yet exist.